### PR TITLE
Atualização das versões do spring-boot java e gradlew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 clean-git-on-subfolders.sh
 .idea
+hs_err_pid*.log
+replay_pid*.log

--- a/08.13-adicionando-novas-dependencias-no-gradle/algasensors/microservices/device-management/build.gradle
+++ b/08.13-adicionando-novas-dependencias-no-gradle/algasensors/microservices/device-management/build.gradle
@@ -1,17 +1,17 @@
 plugins {
-	id 'idea'
-	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'idea'
+    id 'java'
+    id 'org.springframework.boot' version '4.0.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.algaworks.algasensors'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
 }
 
 idea {
@@ -32,13 +32,15 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-h2console'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/08.13-adicionando-novas-dependencias-no-gradle/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/08.13-adicionando-novas-dependencias-no-gradle/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/08.13-adicionando-novas-dependencias-no-gradle/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/08.13-adicionando-novas-dependencias-no-gradle/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,8 +1,8 @@
 plugins {
 	id 'idea'
-	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '4.0.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.algaworks.algasensors'
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,15 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-h2console'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/08.13-adicionando-novas-dependencias-no-gradle/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/08.13-adicionando-novas-dependencias-no-gradle/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/08.13-adicionando-novas-dependencias-no-gradle/algasensors/microservices/temperature-processing/build.gradle
+++ b/08.13-adicionando-novas-dependencias-no-gradle/algasensors/microservices/temperature-processing/build.gradle
@@ -1,17 +1,17 @@
 plugins {
 	id 'idea'
-	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '4.0.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.algaworks.algasensors'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
 }
 
 idea {
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.apache.commons:commons-lang3:3.20.0'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/08.13-adicionando-novas-dependencias-no-gradle/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/08.13-adicionando-novas-dependencias-no-gradle/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/08.14-gerenciando-servicos-na-intellij-idea/algasensors/microservices/device-management/build.gradle
+++ b/08.14-gerenciando-servicos-na-intellij-idea/algasensors/microservices/device-management/build.gradle
@@ -1,17 +1,17 @@
 plugins {
-	id 'idea'
-	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'idea'
+    id 'java'
+    id 'org.springframework.boot' version '4.0.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.algaworks.algasensors'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
 }
 
 idea {
@@ -32,13 +32,15 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-h2console'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/08.14-gerenciando-servicos-na-intellij-idea/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/08.14-gerenciando-servicos-na-intellij-idea/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/08.14-gerenciando-servicos-na-intellij-idea/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/08.14-gerenciando-servicos-na-intellij-idea/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,8 +1,8 @@
 plugins {
 	id 'idea'
-	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '4.0.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.algaworks.algasensors'
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,15 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-h2console'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/08.14-gerenciando-servicos-na-intellij-idea/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/08.14-gerenciando-servicos-na-intellij-idea/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/08.14-gerenciando-servicos-na-intellij-idea/algasensors/microservices/temperature-processing/build.gradle
+++ b/08.14-gerenciando-servicos-na-intellij-idea/algasensors/microservices/temperature-processing/build.gradle
@@ -1,17 +1,17 @@
 plugins {
 	id 'idea'
-	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '4.0.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.algaworks.algasensors'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
 }
 
 idea {
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.apache.commons:commons-lang3:3.20.0'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/08.14-gerenciando-servicos-na-intellij-idea/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/08.14-gerenciando-servicos-na-intellij-idea/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/09.04-usando-o-uuid-v4-e-v7-com-java/algasensors/microservices/device-management/build.gradle
+++ b/09.04-usando-o-uuid-v4-e-v7-com-java/algasensors/microservices/device-management/build.gradle
@@ -1,17 +1,17 @@
 plugins {
-	id 'idea'
-	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'idea'
+    id 'java'
+    id 'org.springframework.boot' version '4.0.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.algaworks.algasensors'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
 }
 
 idea {
@@ -32,13 +32,15 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-h2console'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/09.04-usando-o-uuid-v4-e-v7-com-java/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/09.04-usando-o-uuid-v4-e-v7-com-java/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/09.04-usando-o-uuid-v4-e-v7-com-java/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/09.04-usando-o-uuid-v4-e-v7-com-java/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,8 +1,8 @@
 plugins {
 	id 'idea'
-	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '4.0.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.algaworks.algasensors'
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,15 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-h2console'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/09.04-usando-o-uuid-v4-e-v7-com-java/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/09.04-usando-o-uuid-v4-e-v7-com-java/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/09.04-usando-o-uuid-v4-e-v7-com-java/algasensors/microservices/temperature-processing/build.gradle
+++ b/09.04-usando-o-uuid-v4-e-v7-com-java/algasensors/microservices/temperature-processing/build.gradle
@@ -1,17 +1,17 @@
 plugins {
 	id 'idea'
-	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '4.0.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.algaworks.algasensors'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
 }
 
 idea {
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/09.04-usando-o-uuid-v4-e-v7-com-java/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/09.04-usando-o-uuid-v4-e-v7-com-java/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/09.05-usando-o-tsid-com-java/algasensors/microservices/device-management/build.gradle
+++ b/09.05-usando-o-tsid-com-java/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,14 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/09.05-usando-o-tsid-com-java/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/09.05-usando-o-tsid-com-java/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/09.05-usando-o-tsid-com-java/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/09.05-usando-o-tsid-com-java/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,11 +33,13 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/09.05-usando-o-tsid-com-java/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/09.05-usando-o-tsid-com-java/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/09.05-usando-o-tsid-com-java/algasensors/microservices/temperature-processing/build.gradle
+++ b/09.05-usando-o-tsid-com-java/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/09.05-usando-o-tsid-com-java/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/09.05-usando-o-tsid-com-java/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.02-implementando-um-microsservico-com-spring/algasensors/microservices/device-management/build.gradle
+++ b/10.02-implementando-um-microsservico-com-spring/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,14 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.02-implementando-um-microsservico-com-spring/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.02-implementando-um-microsservico-com-spring/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.02-implementando-um-microsservico-com-spring/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.02-implementando-um-microsservico-com-spring/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,11 +33,13 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.02-implementando-um-microsservico-com-spring/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.02-implementando-um-microsservico-com-spring/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.02-implementando-um-microsservico-com-spring/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.02-implementando-um-microsservico-com-spring/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.02-implementando-um-microsservico-com-spring/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.02-implementando-um-microsservico-com-spring/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.03-implementando-um-serializador/algasensors/microservices/device-management/build.gradle
+++ b/10.03-implementando-um-serializador/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.03-implementando-um-serializador/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.03-implementando-um-serializador/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.03-implementando-um-serializador/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.03-implementando-um-serializador/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.03-implementando-um-serializador/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.03-implementando-um-serializador/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.03-implementando-um-serializador/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.03-implementando-um-serializador/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,11 +33,13 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.03-implementando-um-serializador/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.03-implementando-um-serializador/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.03-implementando-um-serializador/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.03-implementando-um-serializador/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.03-implementando-um-serializador/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.03-implementando-um-serializador/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.04-implementando-a-persistencia/algasensors/microservices/device-management/build.gradle
+++ b/10.04-implementando-a-persistencia/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.04-implementando-a-persistencia/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.04-implementando-a-persistencia/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.04-implementando-a-persistencia/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.04-implementando-a-persistencia/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.04-implementando-a-persistencia/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.04-implementando-a-persistencia/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.04-implementando-a-persistencia/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.04-implementando-a-persistencia/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,11 +33,13 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.04-implementando-a-persistencia/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.04-implementando-a-persistencia/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.04-implementando-a-persistencia/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.04-implementando-a-persistencia/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.04-implementando-a-persistencia/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.04-implementando-a-persistencia/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.05-ajustando-a-representacao-do-recurso-rest-com-classe-model/algasensors/microservices/device-management/build.gradle
+++ b/10.05-ajustando-a-representacao-do-recurso-rest-com-classe-model/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,14 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.05-ajustando-a-representacao-do-recurso-rest-com-classe-model/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.05-ajustando-a-representacao-do-recurso-rest-com-classe-model/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.05-ajustando-a-representacao-do-recurso-rest-com-classe-model/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.05-ajustando-a-representacao-do-recurso-rest-com-classe-model/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,11 +33,13 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.05-ajustando-a-representacao-do-recurso-rest-com-classe-model/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.05-ajustando-a-representacao-do-recurso-rest-com-classe-model/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.05-ajustando-a-representacao-do-recurso-rest-com-classe-model/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.05-ajustando-a-representacao-do-recurso-rest-com-classe-model/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.05-ajustando-a-representacao-do-recurso-rest-com-classe-model/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.05-ajustando-a-representacao-do-recurso-rest-com-classe-model/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/device-management/build.gradle
+++ b/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,11 +33,13 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.06-implementando-a-consulta-de-sensores/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/device-management/build.gradle
+++ b/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,11 +33,13 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.07-implementando-paginacao-de-resultados-da-consulta/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/device-management/build.gradle
+++ b/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,11 +33,13 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.08-yaml-ou-properties-qual-usar/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/device-management/build.gradle
+++ b/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,11 +33,13 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.09-desafio-atualizacao-e-remocao-de-sensor/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/device-management/build.gradle
+++ b/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,11 +33,13 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.10-desafio-inativacao-dos-sensores/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/device-management/build.gradle
+++ b/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,11 +33,13 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.11-implementando-microsservico-de-temperature-processing/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/device-management/build.gradle
+++ b/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.12-setup-do-microsservico-de-temperature-monitoring/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/device-management/build.gradle
+++ b/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.13-implementando-endpoints-do-sensor-monitoring/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/device-management/build.gradle
+++ b/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.14-implementando-a-consulta-do-log-de-temperaturas/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/device-management/build.gradle
+++ b/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
+++ b/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
+++ b/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/temperature-processing/build.gradle
+++ b/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/10.15-desafio-configuracao-de-alertas-para-os-sensores/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/device-management/build.gradle
+++ b/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,16 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-restclient'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
+++ b/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
+++ b/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/temperature-processing/build.gradle
+++ b/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/11.02-integracao-de-rest-api-com-restclient-do-spring/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/device-management/build.gradle
+++ b/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,16 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-restclient'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
+++ b/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
+++ b/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/temperature-processing/build.gradle
+++ b/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/11.03-http-status-codes-para-erros-na-integracao/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.04-lidando-com-erros-de-timeout/algasensors/microservices/device-management/build.gradle
+++ b/11.04-lidando-com-erros-de-timeout/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,16 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-restclient'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.04-lidando-com-erros-de-timeout/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/11.04-lidando-com-erros-de-timeout/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.04-lidando-com-erros-de-timeout/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/11.04-lidando-com-erros-de-timeout/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/11.04-lidando-com-erros-de-timeout/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/11.04-lidando-com-erros-de-timeout/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/11.04-lidando-com-erros-de-timeout/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/11.04-lidando-com-erros-de-timeout/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.04-lidando-com-erros-de-timeout/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/11.04-lidando-com-erros-de-timeout/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.04-lidando-com-erros-de-timeout/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
+++ b/11.04-lidando-com-erros-de-timeout/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/11.04-lidando-com-erros-de-timeout/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
+++ b/11.04-lidando-com-erros-de-timeout/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/11.04-lidando-com-erros-de-timeout/algasensors/microservices/temperature-processing/build.gradle
+++ b/11.04-lidando-com-erros-de-timeout/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.04-lidando-com-erros-de-timeout/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/11.04-lidando-com-erros-de-timeout/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/device-management/build.gradle
+++ b/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,16 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-restclient'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
+++ b/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
+++ b/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/temperature-processing/build.gradle
+++ b/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/11.05-simplificando-a-implementacao-com-factory-pattern/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/device-management/build.gradle
+++ b/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,16 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-restclient'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/StringToTSIDDeserializer.java
+++ b/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/StringToTSIDDeserializer.java
@@ -1,17 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class StringToTSIDDeserializer extends JsonDeserializer<TSID> {
+public class StringToTSIDDeserializer extends ValueDeserializer<TSID> {
 
     @Override
-    public TSID deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+    public TSID deserialize(JsonParser p, DeserializationContext ctxt) {
         return TSID.from(p.getText());
     }
 }

--- a/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         module.addDeserializer(TSID.class, new StringToTSIDDeserializer());

--- a/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
+++ b/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
+++ b/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/temperature-processing/build.gradle
+++ b/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/11.06-implementando-consulta-de-dados-usando-get/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/device-management/build.gradle
+++ b/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/device-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,16 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-restclient'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
+++ b/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/device-management/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/StringToTSIDDeserializer.java
+++ b/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/StringToTSIDDeserializer.java
@@ -1,17 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class StringToTSIDDeserializer extends JsonDeserializer<TSID> {
+public class StringToTSIDDeserializer extends ValueDeserializer<TSID> {
 
     @Override
-    public TSID deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+    public TSID deserialize(JsonParser p, DeserializationContext ctxt) {
         return TSID.from(p.getText());
     }
 }

--- a/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
+++ b/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         module.addDeserializer(TSID.class, new StringToTSIDDeserializer());

--- a/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
+++ b/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/device-management/src/main/java/com/algaworks/algasensors/device/management/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.device.management.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/temperature-monitoring/build.gradle
+++ b/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/temperature-monitoring/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -33,12 +33,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
+++ b/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/temperature-monitoring/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
+++ b/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDJacksonConfig.java
@@ -1,7 +1,7 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.module.SimpleModule;
 import io.hypersistence.tsid.TSID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class TSIDJacksonConfig {
 
     @Bean
-    public Module tsidModule() {
+    public JacksonModule tsidModule() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(TSID.class, new TSIDToStringSerializer());
         return module;

--- a/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
+++ b/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/temperature-monitoring/src/main/java/com/algaworks/algasensors/temperature/monitoring/api/config/jackson/TSIDToStringSerializer.java
@@ -1,16 +1,14 @@
 package com.algaworks.algasensors.temperature.monitoring.api.config.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 import io.hypersistence.tsid.TSID;
 
-import java.io.IOException;
-
-public class TSIDToStringSerializer extends JsonSerializer<TSID> {
+public class TSIDToStringSerializer extends ValueSerializer<TSID> {
 
     @Override
-    public void serialize(TSID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TSID value, JsonGenerator gen, SerializationContext ctxt) {
         gen.writeString(value.toString());
     }
 }

--- a/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/temperature-processing/build.gradle
+++ b/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/temperature-processing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'idea'
 	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -32,13 +32,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
-	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
 	implementation 'io.hypersistence:hypersistence-tsid:2.1.4'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
+++ b/11.07-implementando-client-declarativo-com-http-interface/algasensors/microservices/temperature-processing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Procedimento de migração utilizado

A migração das aulas para Spring Boot 4 foi realizada de forma incremental, utilizando uma aula já validada como base.

### Passos

1.  Utilizado a última aula migrada como referência.
2.  Gerado um patch com as mudanças de infraestrutura (Spring Boot, Java toolchain e Gradle Wrapper) entre a branch de migração e origin/main:
    ```bash
    git diff origin/main...HEAD -- <aula-base> > base-patch.patch
    ```
3.  **Ajuste de Path**: Copiar o patch e ajustar manualmente o path para a próxima aula (salvando o arquivo em UTF-8 sem BOM).
4.  Aplicar o patch em modo seguro:
    ```bash
    git apply --reject --whitespace=fix base-patch.patch
    ```
5.  Caso fossem gerados arquivos `.rej`, revisei visualmente e apliquei apenas as alterações necessárias.
6.  Validado cada microserviço da aula executando:
    ```bash
    ./gradlew build
    ```